### PR TITLE
added 538's scandals csv

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -1,3 +1,4 @@
 # Information and Citation of all Data Utilized
 - raw-polls.csv (*FiveThirtyEight*): A list of all polls conducted in the final three weeks of an election, going back to 1998. 
 - pollster-stats-full (*FiveThirtyEight*): A list of all pollsters and 538's ratings. We don't use their ratings, but we do use two things: Whether a pollster is part of ROPER/AAPOR, and the pollster_rating_id
+- Scandals.csv (*FiveThirtyEight*): A list of all modern political scandals and their results

--- a/data/Scandals.csv
+++ b/data/Scandals.csv
@@ -1,0 +1,256 @@
+Politician,State,Position,Year,Type of Scandal,What Happened,Comeback?
+Jamaal Bowman,New York,Representative,2023,Pulling fire alarm,TBD,N/A
+Jeff Duncan,South Carolina,Representative,2023,Adultery,TBD,N/A
+Bob Menendez,New Jersey,Senator,2023,Bribery,TBD,N/A
+Lauren Boebert,Colorado,Representative,2023,Disorderly behavior,TBD,N/A
+George Santos,New York,Representative,2023,"Sexual harassment, theft",TBD,N/A
+Beth Wood,North Carolina,Auditor,2023,Hit and run,TBD,N/A
+Joe Biden,N/A,President,2023,Mishandling of documents,TBD,N/A
+Alexandria Ocasio-Cortez,New York,Representative,2022,Unknown,TBD,N/A
+Kai Kahele,Hawaii,Representative,2022,"Ethics, misuse of official resources",Lost bid for governor,None
+Kristi Noem,South Dakota,Governor,2022,"Conflict of interest, misuse of funds",Won reelection,N/A
+Vicente Gonzalez,Texas,Representative,2022,Tax fraud,Won reelection,N/A
+William Timmons,South Carolina,Representative,2022,"Adultery, abuse of power",Won reelection,N/A
+Raphael Warnock,Georgia,Senator,2022,Campaign finance,Won reelection,N/A
+Kathy McGuiness,Delaware,Auditor,2022,Corruption,Lost reelection,None
+Ronny Jackson,Texas,Representative,2022,Misuse of funds,Won reelection,N/A
+John Rutherford,Florida,Representative,2022,Nondisclosure,Won reelection,N/A
+Pat Fallon,Texas,Representative,2022,Nondisclosure,Won reelection,N/A
+Anthony Brown,Maryland,Representative,2022,Campaign finance,Won bid for AG,N/A
+Madison Cawthorn,North Carolina,Representative,2022,Misuse of funds,Lost reelection,None
+Madison Cawthorn,North Carolina,Representative,2022,"Improper gifts, adultery",Lost reelection,None
+Madison Cawthorn,North Carolina,Representative,2022,Insider trading,Lost reelection,None
+Madison Cawthorn,North Carolina,Representative,2022,Driving with revoked license,Lost reelection,None
+Tom Suozzi,New York,Representative,2022,???,Lost bid for governor,None
+Brian Benjamin,New York,Lieutenant Governor,2022,Campaign finance,Resigned,None
+Van Taylor,Texas,Representative,2022,Adultery,Retired,None
+Henry Cuellar,Texas,Representative,2022,Corruption,Won reelection,N/A
+Marie Newman,Illinois,Representative,2021,Bribery,Lost reelection,None
+Jeff Fortenberry,Nebraska,Representative,2021,"Campaign finance, lying to the FBI",Resigned,None
+Fiona Ma,California,Treasurer,2021,Sexual harassment,Won reelection,N/A
+Mike Hunter,Oklahoma,Attorney General,2021,Adultery,Resigned,None
+Marjorie Taylor Greene,Georgia,Representative,2021,Tax fraud,Won reelection,N/A
+Doug Lamborn,Colorado,Representative,2021,Misuse of resources,Won reelection,N/A
+Jeff Landry,Louisiana,Attorney General,2021,Sexual harassment coverup,TBD,N/A
+John Merrill,Alabama,Secretary of State,2021,Adultery,Was term-limited out,None
+Matt Gaetz,Florida,Representative,2021,"Sex with underage girl, misuse of funds, drug use, prostitution, corruption, obstruction of justice",Won reelection,N/A
+Madison Cawthorn,North Carolina,Representative,2021,Weapons possession,Lost reelection,None
+Tom Reed,New York,Representative,2021,Sexual harassment,Retired,None
+Tom Malinowski,New Jersey,Representative,2021,Nondisclosure,Lost reelection,None
+Ronny Jackson,Texas,Representative,2021,Sexual harassment,Won reelection,N/A
+Andrew Cuomo,New York,Governor,2021,"Sexual harassment, sexual assault (groping)",Resigned,None
+Andrew Cuomo,New York,Governor,2020,Public-records coverup,Resigned,None
+Jim Hagedorn,Minnesota,Representative,2020,Misuse of funds,Died in office,N/A
+Jason Ravnsborg,South Dakota,Attorney General,2020,Manslaughter,Removed,None
+Alex Mooney,West Virginia,Representative,2020,Misuse of funds,Won reelection,N/A
+Mike Kelly,Pennsylvania,Representative,2020,Insider trading,Won reelection,N/A
+Sanford Bishop,Georgia,Representative,2020,Misuse of funds,Won reelection,N/A
+Steve Watkins,Kansas,Representative,2020,Election fraud,Lost reelection,None
+Steven Horsford,Nevada,Representative,2020,Adultery,Won reelection,N/A
+Matt Gaetz,Florida,Representative,2020,Conflict of interest,Won reelection,N/A
+Donna Shalala,Florida,Representative,2020,Nondisclosure,Lost reelection,None
+Steven Palazzo,Mississippi,Representative,2020,Misuse of funds,"Won reelection, then lost reelection",N/A
+Kelly Loeffler,Georgia,Senator,2020,Insider trading,Lost bid for full term,None
+Richard Burr,North Carolina,Senator,2020,Insider trading,Announced retirement before scandal,None
+Michelle Lujan Grisham,New Mexico,Governor,2019,Sexual harassment,Won reelection,N/A
+Bill Huizenga,Michigan,Representative,2019,Misuse of funds,Won reelection,N/A
+Alcee Hastings,Florida,Representative,2019,Inappropriate relationship with staffer,Won reelection,N/A
+Eric Holcomb,Indiana,Governor,2019,Abuse of power,Won reelection,N/A
+Katie Hill,California,Representative,2019,Adultery (with staffer),Resigned,None
+Ilhan Omar,Minnesota,Representative,2019,"Adultery, campaign finance",Won reelection,N/A
+Jim Beck,Georgia,Insurance Commissioner,2019,Fraud,Removed,None
+Matt Gaetz,Florida,Representative,2019,Witness intimidation,Won reelection,N/A
+JB Pritzker,Illinois,Governor,2019,Tax fraud,Won reelection,N/A
+Rashida Tlaib,Michigan,Representative,2019,Campaign finance,Won reelection,N/A
+Mark Herring,Virginia,Attorney General,2019,Blackface,Lost reelection,None
+Justin Fairfax,Virginia,Lieutenant Governor,2019,Sexual assault (rape),Lost bid for governor,None
+Ralph Northam,Virginia,Governor,2019,Blackface,Was term-limited out,None
+Curtis Hill,Indiana,Attorney General,2018,Sexual assault (groping),Lost reelection,None
+Henry Cuellar,Texas,Representative,2019,Employment discrimination,Won reelection,N/A
+John Hickenlooper,Colorado,Governor,2018,Illegal gifts,Was term-limited out,Won 2020 bid for Senate
+Mia Love,Utah,Representative,2018,Campaign finance,Lost reelection,None
+Adam Laxalt,Nevada,Attorney General,2018,Assault (of police officer as a teenager),Lost bid for governor,None
+Rod Blum,Iowa,Representative,2018,Nondisclosure,Lost reelection,None
+Scott Taylor,Virginia,Representative,2018,Election fraud,Lost reelection,Lost 2020 bid for Congress
+David Schweikert,Arizona,Representative,2018,"Campaign finance, misuse of funds",Won reelection,N/A
+Keith Ellison,Minnesota,Representative,2018,Domestic abuse,Won bid for AG,N/A
+Tom Garrett,Virginia,Representative,2018,Misuse of resources,Retired,None
+Rick Nolan,Minnesota,Representative,2018,Sexual harassment coverup,Lost bid for LG,None
+Bill Schuette,Michigan,Attorney General,2018,Misuse of resources,Lost bid for governor,None
+Jim Jordan,Ohio,Representative,2018,Sexual harassment coverup,Won reelection,N/A
+Kris Kobach,Kansas,Secretary of State,2018,Contempt of court,Lost bid for governor,"Lost 2020 bid for Senate, won 2022 bid for AG"
+Eric Schneiderman,New York,Attorney General,2018,Domestic abuse,Resigned,None
+Tony Cárdenas,California,Representative,2018,Sexual assault (of a teenager),Won reelection,N/A
+Jimmy Duncan Jr.,Tennessee,Representative,2018,Misuse of funds,Retired,None
+Elizabeth Esty,Connecticut,Representative,2018,Sexual harassment coverup,Retired,None
+Tom Schedler,Louisiana,Secretary of State,2018,Sexual harassment,Resigned,None
+Patrick Meehan,Pennsylvania,Representative,2018,Sexual harassment,Resigned,None
+Eric Greitens,Missouri,Governor,2018,"Adultery, sexual assault (rape), campaign finance",Resigned,Lost 2022 bid for Senate
+Raúl Grijalva,Arizona,Representative,2017,Hostile work environment ,Won reelection,N/A
+Bobby Scott,Virginia,Representative,2017,Sexual harassment,Won reelection,N/A
+Ed Murray,Wyoming,Secretary of State,2017,Sexual assault,Resigned,None
+Trent Franks,Arizona,Representative,2017,Sexual harassment,Resigned,None
+Rubén Kihuen,Nevada,Representative,2017,Sexual harassment,Retired,None
+Joe Barton,Texas,Representative,2017,"Adultery, sexual harassment",Retired,None
+John Conyers,Michigan,Representative,2017,"Sexual harassment, sexual assault (groping)",Resigned,None
+Al Franken,Minnesota,Senator,2017,Sexual assault (groping),Resigned,None
+Dana Rohrabacher,California,Representative,2017,Election collusion,Lost reelection,None
+Chris Collins,New York,Representative,2017,"Conflict of interest, insider trading","Won reelection, then resigned",None
+Tim Murphy,Pennsylvania,Representative,2017,Adultery,Resigned,None
+Bob Brady,Pennsylvania ,Representative,2017,Corruption,Retired,None
+Mike Stack,Pennsylvania ,Lieutenant Governor,2017,Hostile work environment,Lost reelection,None
+Duncan D. Hunter,California,Representative,2017,"Misuse of funds, adultery","Won reelection, then resigned",None
+Donald Trump,N/A,President,2017,"Election collusion, adultery, sexual assault, tax fraud, abuse of power",Lost reelection,None
+Devin Nunes,California,Representative,2017,Divulging classified information,"Won reelection, then resigned unrelatedly",N/A
+Charles Boustany,Louisiana,Representative,2016,Sex with prostitute,Lost bid for Senate,None
+Ed Whitfield,Kentucky,Representative,2016,Ethics,Resigned,None
+Terry McAuliffe,Virginia,Governor,2016,Campaign finance,Was term-limited out,Lost 2021 bid for governor
+Robert Pittenger,North Carolina,Representative,2016,Campaign finance,"Won reelection, then lost reelection",None
+Roy Moore,Alabama,Supreme Court Justice,2016,Insubordination,Removed,Lost 2017 bid for Senate
+Mark Meadows,North Carolina,Representative,2016,Sexual harassment coverup,Won reelection,N/A
+Sid Miller,Texas,Agriculture Commissioner,2016,Ethics,Won reelection,N/A
+Alan Grayson,Florida,Representative,2016,"Ethics, abuse",Lost bid for Senate,Lost 2018 bid for Congress
+Corrine Brown,Florida,Representative,2016,Fraud,Lost reelection,None
+Mike Honda,California,Representative,2015,Campaign finance,Lost reelection,None
+Robert Bentley,Alabama,Governor,2015,Sex,Resigned,None
+Drew Wrigley,North Dakota,Lieutenant Governor,2015,Sex,Retired,None
+Dianna Duran,New Mexico,Secretary of State,2015,Campaign finance,Resigned,None
+Chaka Fattah,Pennsylvania,Representative,2015,Campaign finance,Resigned,None
+Ken Paxton,Texas,Attorney General,2015,Fraud,Won reelection,N/A
+Paul LePage,Maine,Governor,2015,Abuse of power,Was term-limited out,Lost 2022 bid for governor
+James Comer,Kentucky,Agriculture Commissioner,2015,Abuse,Lost bid for governor,Won 2016 bid for Congress
+Frank Guinta,New Hampshire,Representative,2015,Campaign finance,Lost reelection,None
+Bill Sorrell,Vermont,Attorney General,2015,Campaign finance,Retired,None
+Troy Kelley,Washington,Auditor,2015,Fraud,Retired,None
+Bob Menendez,New Jersey,Senator,2015,Corruption,Won reelection,N/A
+Aaron Schock,Illinois,Representative,2015,Ethics,Resigned,None
+John Kitzhaber,Oregon,Governor,2014,Ethics,Resigned,None
+Rob McCord,Pennsylvania,Treasurer,2015,Campaign finance,Resigned,None
+Kathleen Kane,Pennsylvania,Attorney General,2015,Abuse of power,Resigned,None
+Henry McMaster,South Carolina,Lieutenant Governor,2015,Campaign finance,"Elevated to governor, won full term",N/A
+Blake Farenthold,Texas,Representative,2014,Sex,"Won reelection twice, then resigned",None
+Lavon Heidemann,Nebraska,Lieutenant Governor,2014,Abuse,Resigned,None
+Chip Flowers,Delaware,Treasurer,2014,Sex & ethics,Retired,None
+Rick Perry,Texas,Governor,2014,Abuse of power,"Retired, then lost bid for president",Became secretary of energy
+John Walsh,Montana,Senator,2014,Plagiarism,Retired,None
+Scott Walker,Wisconsin,Governor,2014,Campaign finance,Won reelection,N/A
+Nathan Deal,Georgia,Governor,2014,Ethics,Won reelection,N/A
+Don Young,Alaska,Representative,2014,Campaign finance,Won reelection,N/A
+Vance McAllister,Louisiana,Representative,2014,Sex,Lost reelection,None
+Dan Rutherford,Illinois,Treasurer,2014,Sex & ethics,Lost bid for governor,None
+Chris Christie,New Jersey,Governor,2014,Abuse of power,"Lost bid for president, then was term-limited out",None
+Mark Darr,Arkansas,Lieutenant Governor,2014,Campaign finance & ethics,Resigned,None
+Cathy McMorris Rodgers,Washington,Representative,2014,Misuse of funds,Won reelection,N/A
+Trey Radel,Florida,Representative,2013,Drugs,Resigned,None
+Cindy Hill,Wyoming,Superintendent,2013,Abuse,Lost bid for governor,None
+Joan Orie Melvin,Pennsylvania,Supreme Court Justice,2013,Corruption,Resigned,None
+Michele Bachmann,Minnesota,Representative,2013,Ethics,Retired,None
+Martha Shoffner,Arkansas,Treasurer,2013,Corruption,Resigned,None
+Bob McDonnell,Virginia,Governor,2013,Ethics,Was term-limited out,None
+Diane Hathaway,Michigan,Supreme Court Justice,2013,Fraud,Resigned,None
+Jennifer Carroll,Florida,Lieutenant Governor,2013,Ethics,Resigned,None
+John Swallow,Utah,Attorney General,2013,Corruption,Resigned,None
+Rick Sheehy,Nebraska,Lieutenant Governor,2013,Sex,Resigned,None
+Mike Crapo,Idaho,Senator,2012,DUI,Won reelection,N/A
+Dustin McDaniel,Arkansas,Attorney General,2012,Sex,"Dropped bid for governor, was term-limited out",None
+Michael Grimm,New York,Representative,2012,Campaign finance & fraud,"Won reelection, then resigned",None
+Charlie White,Indiana,Secretary of State,2012,Fraud,Removed,None
+Jesse Jackson Jr.,Illinois,Representative,2012,Campaign finance & fraud,Resigned,None
+Ken Ard,South Carolina,Lieutenant Governor,2012,Campaign finance,Resigned,None
+David Rivera,Florida,Representative,2012,Campaign finance,Lost reelection,None
+Laura Richardson,California,Representative,2012,Ethics,Lost reelection,None
+Scott DesJarlais,Tennessee,Representative,2012,Sex,Won reelection,N/A
+Tom Horne,Arizona,Attorney General,2012,Sex & campaign finance,Lost reelection,None
+Anthony Weiner,New York,Representative,2011,Sex,Resigned,Lost 2013 bid for New York City mayor
+Chris Lee,New York,Representative,2011,Sex,Resigned,None
+David Wu,Oregon,Representative,2011,Sex,Resigned,None
+John Ensign,Nevada,Senator,2011,Sex & ethics,Resigned,None
+Alcee Hastings,Florida,Representative,2011,Sex,Won reelection,N/A
+John Tierney,Massachusetts,Representative,2010,Ethics,"Won reelection twice, then lost reelection",None
+Eric Massa,New York,Representative,2010,Sex,Resigned,None
+Mark Souder,Indiana,Representative,2010,Sex,Resigned,None
+Maxine Waters,California,Representative,2009,Ethics,Won reelection,N/A
+Mark Sanford,South Carolina,Governor,2009,Sex,Was term-limited out,Won 2013 bid for Congress
+Rod Blagojevich,Illinois,Governor,2009,Corruption,Removed,None
+Sharon Keller,Texas,Criminal Appeals Judge,2009,Ethics & insubordination,Won reelection,N/A
+Charlie Rangel,New York,Representative,2008,Ethics,Won reelection,N/A
+Eliot Spitzer,New York,Governor,2008,Sex,Resigned,Lost 2013 bid for New York City comptroller
+Jeff McMahan,Oklahoma,Auditor,2008,Corruption,Resigned,None
+Jim Gibbons,Nevada,Governor,2008,"Sex, campaign finance, & ethics",Lost reelection,None
+John Doolittle,California,Representative,2008,Corruption,Retired,None
+Marc Dann,Ohio,Attorney General,2008,Sex,Resigned,None
+Rick Renzi,Arizona,Representative,2008,Corruption & fraud,Retired,None
+Sarah Palin,Alaska,Governor,2008,Ethics,Resigned,None
+Ted Stevens,Alaska,Senator,2008,Corruption,Lost reelection,None
+Tim Mahoney,Florida,Representative,2008,Sex,Lost reelection,None
+Vito Fossella,New York,Representative,2008,Sex,Retired,None
+David Vitter,Louisiana,Senator,2007,Sex,"Won reelection, then lost bid for governor",None
+Larry Craig,Idaho,Senator,2007,Sex,Retired,None
+Paul Morrison,Kansas,Attorney General,2007,Sex,Resigned,None
+Thomas Ravenel,South Carolina,Treasurer,2007,Drugs,Resigned,None
+David Scott,Georgia,Representative,2007,Campaign finance,Won reelection,N/A
+David Petersen,Arizona,Treasurer,2006,Campaign finance & ethics,Resigned,None
+John Conyers,Michigan,Representative,2006,Ethics,Won reelection,N/A
+Douglas Martin,Arizon,State Mine Inspector,2006,Fraud,Retired,None
+Bill Jefferson,Louisiana,Representative,2006,Corruption,"Won reelection, then lost reelection",None
+Bob Ney,Ohio,Representative,2006,Corruption,Resigned,None
+Mark Foley,Florida,Representative,2006,Sex,Resigned,None
+Mike Easley,North Carolina,Governor,2006,Campaign finance & ethics,Was term-limited out,None
+Bob Taft,Ohio,Governor,2005,Ethics,Was term-limited out,None
+Don Sherwood,Pennsylvania,Representative,2005,Sex,Lost reelection,None
+Duke Cunningham,California,Representative,2005,Corruption & fraud,Resigned,None
+Ernie Fletcher,Kentucky,Governor,2005,Ethics,Lost reelection,None
+Robert Vigil,New Mexico,Treasurer,2005,Corruption,Resigned,None
+Tom DeLay,Texas,Representative,2005,Campaign finance & corruption,Resigned,None
+Ed Schrock,Virginia,Representative,2004,Sex,Retired,None
+Frank Ballance,North Carolina,Representative,2004,Fraud,Resigned,None
+Jim McGreevey,New Jersey,Governor,2004,Sex,Resigned,None
+Kathy Augustine,Nevada,Controller,2004,Ethics,"Ran for treasurer, died mid-campaign",N/A
+Kevin Shelley,California,Secretary of State,2004,Campaign finance,Resigned,None
+Bill Janklow,South Dakota,Representative,2003,Manslaughter,Resigned,None
+Bob Wise,West Virginia,Governor,2003,Sex,Retired,None
+John Rowland,Connecticut,Governor,2003,Corruption,Resigned,None
+Lorelee Byrd,Nebraska,Treasurer,2003,Ethics,Resigned,None
+Meg Scott Phipps,North Carolina,Agriculture Commissioner,2003,Campaign finance & fraud,Resigned,None
+Roy Moore,Alabama,Supreme Court Justice,2003,Insubordination,Removed,Lost 2010 bid for governor; won 2012 bid to return to Supreme Court
+Steve LaTourette,Ohio,Representative,2003,Sex,Won reelection,N/A
+George Ryan,Illinois,Governor,2002,Corruption,Retired,None
+Jim Traficant,Ohio,Representative,2002,Corruption,Removed,Lost 2002 & 2010 bids for old seat
+Paul Patton,Kentucky,Governor,2002,Sex,Retired,None
+Robert Torricelli,New Jersey,Senator,2002,Campaign finance,Retired,None
+Gary Condit,California,Representative,2001,Sex,Lost reelection,None
+Chuck Quackenbush,California,Insurance Commissioner,2000,Corruption,Resigned,None
+Jim Brown,Louisiana,Insurance Commissioner,2000,Ethics & fraud,"Won reelection, then resigned",None
+Bob Barr,Georgia,Representative,1999,Sex,Won reelection,N/A
+Bob Livingston,Louisiana,Representative,1999,Sex,Resigned,None
+Mary Fallin,Oklahoma,Lieutenant Governor,1998,Sex,Won reelection,N/A
+Bill Clinton,N/A,President,1998,Sex,Was term-limited out,N/A
+Dan Burton,Indiana,Representative,1998,Sex,Won reelection,N/A
+Helen Chenoweth-Hage,Idaho,Representative,1998,Sex,Won reelection,N/A
+Henry Hyde,Illinois,Representative,1998,Sex,Won reelection,N/A
+Fife Symington,Arizona,Governor,1997,Fraud,Resigned,Lost 2006 bid for local GOP chairmanship
+Jay Kim,California,Representative,1997,Campaign finance,Lost reelection,Lost 2000 bid for old seat
+Newt Gingrich,Georgia,Representative,1997,Ethics & sex,"Won reelection, then resigned",Ran for president in 2012
+Barbara-Rose Collins,Michigan,Representative,1996,Campaign finance & ethics,Lost reelection,Won 2001 bid for Detroit City Council; reelected in 2005
+Jim Guy Tucker,Arkansas,Governor,1996,Fraud,Resigned,None
+Wes Cooley,Oregon,Representative,1996,Ethics,Retired,None
+Bob Packwood,Oregon,Senator,1995,Sex,Resigned,None
+Ernie Preate,Pennsylvania,Attorney General,1995,Corruption & fraud,Resigned,None
+Walter Tucker III,California,Representative,1995,Corruption,Resigned,None
+Austin Murphy,Pennsylvania,Representative,1994,Ethics & sex,Retired,None
+Dan Rostenkowski,Illinois,Representative,1994,Ethics & fraud,Lost reelection,None
+Judith Moriarty,Missouri,Secretary of State,1994,Ethics,Removed,Lost 2002 bid for State House
+Mel Reynolds,Illinois,Representative,1994,Sex,"Won reelection, then resigned",Lost 2004 & 2013 bids for old seat
+Ken Calvert,California,Representative,1993,Sex,Won reelection,N/A
+Carl Perkins,Kentucky,Representative,1992,Campaign finance,Retired,None
+Carroll Hubbard,Kentucky,Representative,1992,Campaign finance,Lost reelection,Lost 2006 & 2008 bids for State Senate
+Brock Adams,Washington,Senator,1992,Sex,Retired,None
+H. Guy Hunt,Alabama,Governor,1992,Ethics,Resigned,None
+Lawrence Smith,Florida,Representative,1992,Campaign finance,Retired,None
+Mary Rose Oakar,Ohio,Representative,1992,Campaign finance & ethics,Lost reelection,Won 2000 bid for State House; lost 2001 bid for Cleveland mayor; won 2012 bid for state board of education
+Nicholas Mavroules,Massachusetts,Representative,1992,Corruption,Lost reelection,None
+William Webster,Missouri,Attorney General,1992,Corruption,Lost bid for governor,None
+Chuck Robb,Virginia,Senator,1991,Sex,Won reelection,N/A
+David Durenberger,Minnesota,Senator,1990,Ethics,Retired,None
+Edward DiPrete,Rhode Island,Governor,1990,Corruption,Lost reelection,None
+Buz Lukens,Ohio,Representative,1989,Sex,"Lost reelection, then resigned",None


### PR DESCRIPTION
This branch includes the initial code for 538's list of modern political scandals. We will soon edit this data to just include the name of the person with the scandal (and possibly the date?), so we can include scandals as part of our model